### PR TITLE
removing warning on recent leaflet versions

### DIFF
--- a/src/Pattern.js
+++ b/src/Pattern.js
@@ -3,7 +3,8 @@
  */
 
 L.Pattern = L.Class.extend({
-	includes: [L.Mixin.Events],
+	// L.Mixin.Events is deprecated
+	includes: [L.Evented.prototype || L.Mixin.Events],
 
 	options: {
 		x: 0,


### PR DESCRIPTION
Hello,
This is my first contribution attempt :-D

I just followed instructions given [here ](https://github.com/Leaflet/Leaflet/issues/5358) to get rid on the deprecated warning with leaflet versions after 1.0.
This works, at least on my environment :-)